### PR TITLE
feat: Soft Delete Room Message(s) (`PUT /api/v1/room-messages/:message_id`)

### DIFF
--- a/app/dto/v1/room_message_dto.py
+++ b/app/dto/v1/room_message_dto.py
@@ -174,3 +174,55 @@ class UpdateRoomMessageResponseDto(BaseModel):
     )
     status_code: int = Field(default=200, examples=[200])
     data: RoomMessageBaseDto
+
+
+# +++++++++++++++++++++++++++++++++++++++ delete message +++++++++++++++++++++++++++++++++++++++++
+
+
+class DeleteRoomMessageDto(BaseModel):
+    """
+    Schema for message delete
+    """
+
+    message_ids: List[
+        Annotated[
+            str, StringConstraints(min_length=10, max_length=60, strip_whitespace=True)
+        ]
+    ] = Field(
+        examples=[["12312432-42345435-4564645", "1234324-23453-53454-645"]],
+        description="ID of messages to delete. only 10 message IDs per request",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_fields(cls, values: dict) -> dict:
+        """
+        Validates fields
+        """
+        if isinstance(values, bytes):
+            values = json.loads(values)
+        message_ids: list | None = values.get("message_ids", None)
+
+        if message_ids:
+            if len(message_ids) > 10:
+                raise ValueError("can only delete 10 messages at a time")
+            if len(message_ids) < 0:
+                raise ValueError("must provide message for deletion")
+
+        return values
+
+
+class DeleteRoomMessageResponseDto(BaseModel):
+    """
+    Delete message schema
+    """
+
+    message: str = Field(
+        default="message(s) deleted successfully",
+        examples=["message(s) deleted successfully"],
+    )
+    status_code: int = Field(default=200, examples=[200])
+    data: dict = Field(
+        default={},
+        examples=[{}],
+    )

--- a/app/route/v1/room_message_route.py
+++ b/app/route/v1/room_message_route.py
@@ -14,6 +14,8 @@ from app.dto.v1.room_message_dto import (
     RoomMessageOrderEnum,
     UpdateRoomMessageDto,
     UpdateRoomMessageResponseDto,
+    DeleteRoomMessageDto,
+    DeleteRoomMessageResponseDto,
 )
 from app.utils.responses import responses
 from app.core.security import validate_logout_status
@@ -130,6 +132,44 @@ async def update_messages(
         HTTPException 400: when Cannot update after 15 minutes of sending a message.
     """
     return await room_message_service.update_message(
+        room_id=room_id,
+        session=session,
+        request=request,
+        schema=schema,
+    )
+
+
+@room_message_router.put(
+    "/{room_id}",
+    status_code=status.HTTP_200_OK,
+    responses=responses,
+    response_model=DeleteRoomMessageResponseDto,
+    dependencies=[Depends(validate_logout_status)],
+)
+async def delete_messages(
+    request: Request,
+    room_id: str,
+    session: typing.Annotated[AsyncSession, Depends(get_async_session)],
+    schema: DeleteRoomMessageDto,
+) -> typing.Optional[DeleteRoomMessageResponseDto]:
+    """
+    Deletes a room messages.
+
+    Return:
+        Success message upon success
+    Raises:
+        HTTPException 401: when not authenticated.
+        HTTPException 401: when invalid access token.
+        HTTPException 401: when access token is blacklisted.
+        HTTPException 404: when room not found.
+        HTTPException 404: when message not found.
+        HTTPException 403: when Room is deactivated.
+        HTTPException 403: when User not a member.
+        HTTPException 403: when User already left room.
+        HTTPException 403: when User does not have enough access to message.
+        HTTPException 400: when Cannot delete after 15 minutes of sending a message.
+    """
+    return await room_message_service.delete_room_messages(
         room_id=room_id,
         session=session,
         request=request,

--- a/app/tests/v1/room_message/test_e2e_delete_room_message.py
+++ b/app/tests/v1/room_message/test_e2e_delete_room_message.py
@@ -1,0 +1,688 @@
+"""
+Test delete room messages
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.tests.v1.room_message import register_input, uuid4
+from app.models.room_member import RoomMember
+from app.models.room import Room
+from app.models.room_message import RoomMessage
+from app.models.user import User
+
+
+class TestDeleteRoomMessages:
+    """
+    Test delete room message route
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_user_can_delete_room_message_successfully(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests user can delete new room message successfully
+        """
+
+        # create user
+        email = f"{uuid4()}@gmail.com"
+        user = User(
+            email=email,
+            profile_photo="https://photo.com",
+            email_verified=True,
+        )
+        await user.set_idempotency_key(email)
+        user.set_password(register_input.get("password", ""))
+
+        # create room and add room member
+        new_room = Room(owner=user, name="Greatestest room", messages_delete_able=True)
+        new_member = RoomMember(
+            member=user,
+            is_admin=True,
+            room=new_room,
+            left_room=False,
+        )
+        room_message = RoomMessage(sender=user, content="I am the Man", room=new_room)
+
+        test_get_session.add_all([user, new_room, new_member, room_message])
+        await test_get_session.commit()
+        await test_get_session.flush()
+
+        # login user
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": email,
+            "session_id": str(uuid4()),
+        }
+
+        response = await client.post(url="/api/v1/auth/login", json=login_payload)
+
+        assert response.status_code == 200
+
+        data: dict = response.json()
+
+        access_token = data["data"]["access_token"]["token"]
+
+        # delete room message
+
+        message_response = await client.put(
+            url=f"/api/v1/room-messages/{new_room.id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"message_ids": [room_message.id]},
+        )
+
+        assert message_response.status_code == 200
+
+        message_data = message_response.json()
+
+        assert message_data["message"] == "message(s) deleted successfully"
+
+        await test_get_session.refresh(room_message)
+
+        assert room_message.is_deleted is True
+
+    @pytest.mark.asyncio
+    async def test_b_when_room_not_found_returns_404(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when room not found returns 404
+        """
+
+        # create user
+        email = f"{uuid4()}@gmail.com"
+        user = User(
+            email=email,
+            profile_photo="https://photo.com",
+            email_verified=True,
+        )
+        await user.set_idempotency_key(email)
+        user.set_password(register_input.get("password", ""))
+
+        test_get_session.add_all([user])
+        await test_get_session.commit()
+        await test_get_session.flush()
+
+        # login user
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": email,
+            "session_id": str(uuid4()),
+        }
+
+        response = await client.post(url="/api/v1/auth/login", json=login_payload)
+
+        assert response.status_code == 200
+
+        data: dict = response.json()
+
+        access_token = data["data"]["access_token"]["token"]
+
+        message_response = await client.put(
+            url="/api/v1/room-messages/13142423445435436564",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={
+                "message_ids": ["12321-3423-54354-55654"],
+            },
+        )
+
+        assert message_response.status_code == 404
+
+        message_data = message_response.json()
+
+        assert message_data["message"] == "Room not found"
+
+    @pytest.mark.asyncio
+    async def test_c_when_user_not_room_member_returns_403(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when user not room member returns 403
+        """
+
+        # create user
+        email = f"{uuid4()}@gmail.com"
+        user = User(
+            email=email,
+            profile_photo="https://photo.com",
+            email_verified=True,
+        )
+        await user.set_idempotency_key(email)
+        user.set_password(register_input.get("password", ""))
+
+        email2 = f"{uuid4()}@gmail.com"
+        user2 = User(
+            email=email2,
+            profile_photo="https://photo.com",
+            email_verified=True,
+        )
+        await user2.set_idempotency_key(email2)
+        user2.set_password(register_input.get("password", ""))
+
+        # create room and add room member
+        new_room = Room(owner=user, name="Greatestest room", messages_delete_able=True)
+        new_member = RoomMember(
+            member=user,
+            is_admin=True,
+            room=new_room,
+            left_room=False,
+        )
+        room_message = RoomMessage(sender=user, content="I am the Man", room=new_room)
+
+        test_get_session.add_all([user, new_room, new_member, room_message, user2])
+        await test_get_session.commit()
+        await test_get_session.flush()
+
+        # login user
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": email2,
+            "session_id": str(uuid4()),
+        }
+
+        response = await client.post(url="/api/v1/auth/login", json=login_payload)
+
+        assert response.status_code == 200
+
+        data: dict = response.json()
+
+        access_token = data["data"]["access_token"]["token"]
+
+        message_response = await client.put(
+            url=f"/api/v1/room-messages/{new_room.id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"message_ids": [room_message.id]},
+        )
+
+        assert message_response.status_code == 403
+
+        message_data = message_response.json()
+
+        assert message_data["message"] == "User not Room member"
+
+    @pytest.mark.asyncio
+    async def test_d_when_user_left_room_returns_403(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when user left room returns 403
+        """
+
+        # create user
+        email = f"{uuid4()}@gmail.com"
+        user = User(
+            email=email,
+            profile_photo="https://photo.com",
+            email_verified=True,
+        )
+        await user.set_idempotency_key(email)
+        user.set_password(register_input.get("password", ""))
+
+        # create room and add room member
+        new_room = Room(owner=user, name="Greatestest room", messages_delete_able=True)
+        new_member = RoomMember(
+            member=user,
+            is_admin=True,
+            room=new_room,
+            left_room=True,
+        )
+        room_message = RoomMessage(sender=user, content="I am the Man", room=new_room)
+
+        test_get_session.add_all([user, new_room, new_member, room_message])
+        await test_get_session.commit()
+        await test_get_session.flush()
+
+        # login user
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": email,
+            "session_id": str(uuid4()),
+        }
+
+        response = await client.post(url="/api/v1/auth/login", json=login_payload)
+
+        assert response.status_code == 200
+
+        data: dict = response.json()
+
+        access_token = data["data"]["access_token"]["token"]
+
+        message_response = await client.put(
+            url=f"/api/v1/room-messages/{new_room.id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"message_ids": [room_message.id]},
+        )
+
+        assert message_response.status_code == 403
+
+        message_data = message_response.json()
+
+        assert message_data["message"] == "User already left room"
+
+    @pytest.mark.asyncio
+    async def test_e_when_message_not_found_returns_404(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when message not found returns 404
+        """
+
+        # create user
+        email = f"{uuid4()}@gmail.com"
+        user = User(
+            email=email,
+            profile_photo="https://photo.com",
+            email_verified=True,
+        )
+        await user.set_idempotency_key(email)
+        user.set_password(register_input.get("password", ""))
+
+        # create room and add room member
+        new_room = Room(owner=user, name="Greatestest room", messages_delete_able=True)
+        new_member = RoomMember(
+            member=user,
+            is_admin=True,
+            room=new_room,
+            left_room=False,
+        )
+        room_message = RoomMessage(sender=user, content="I am the Man", room=new_room)
+
+        test_get_session.add_all([user, new_room, new_member, room_message])
+        await test_get_session.commit()
+        await test_get_session.flush()
+
+        # login user
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": email,
+            "session_id": str(uuid4()),
+        }
+
+        response = await client.post(url="/api/v1/auth/login", json=login_payload)
+
+        assert response.status_code == 200
+
+        data: dict = response.json()
+
+        access_token = data["data"]["access_token"]["token"]
+
+        # delete room message
+
+        message_response = await client.put(
+            url=f"/api/v1/room-messages/{new_room.id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={
+                "message_ids": ["fake-message_id-eeeqq2133"],
+            },
+        )
+
+        assert message_response.status_code == 404
+
+        message_data = message_response.json()
+
+        assert (
+            message_data["message"]
+            == "Message with id fake-message_id-eeeqq2133 not found"
+        )
+
+    @pytest.mark.asyncio
+    async def test_f_when_message_is_already_deleted_returns_404(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when message is already deleted returns 404
+        """
+
+        # create user
+        email = f"{uuid4()}@gmail.com"
+        user = User(
+            email=email,
+            profile_photo="https://photo.com",
+            email_verified=True,
+        )
+        await user.set_idempotency_key(email)
+        user.set_password(register_input.get("password", ""))
+
+        # create room and add room member
+        new_room = Room(owner=user, name="Greatestest room", messages_delete_able=True)
+        new_member = RoomMember(
+            member=user,
+            is_admin=True,
+            room=new_room,
+            left_room=False,
+        )
+        room_message = RoomMessage(
+            sender=user, content="I am the Man", room=new_room, is_deleted=True
+        )
+
+        test_get_session.add_all([user, new_room, new_member, room_message])
+        await test_get_session.commit()
+        await test_get_session.flush()
+
+        # login user
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": email,
+            "session_id": str(uuid4()),
+        }
+
+        response = await client.post(url="/api/v1/auth/login", json=login_payload)
+
+        assert response.status_code == 200
+
+        data: dict = response.json()
+
+        access_token = data["data"]["access_token"]["token"]
+
+        # delete room message
+
+        message_response = await client.put(
+            url=f"/api/v1/room-messages/{new_room.id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"message_ids": [room_message.id]},
+        )
+
+        assert message_response.status_code == 404
+
+        message_data = message_response.json()
+
+        assert (
+            message_data["message"]
+            == f"Message with id {room_message.id} was not found"
+        )
+
+    @pytest.mark.asyncio
+    async def test_g_when_user_deletes_another_user_message_returns_403(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when user deletes another user message returns 403
+        """
+
+        # create user1
+        email = f"{uuid4()}@gmail.com"
+        user = User(
+            email=email,
+            profile_photo="https://photo.com",
+            email_verified=True,
+        )
+        await user.set_idempotency_key(email)
+        user.set_password(register_input.get("password", ""))
+        # create user2
+        email2 = f"{uuid4()}@gmail.com"
+        user2 = User(
+            email=email2,
+            profile_photo="https://photo.com",
+            email_verified=True,
+        )
+        await user2.set_idempotency_key(email2)
+        user2.set_password(register_input.get("password", ""))
+
+        # create room and add room member
+        new_room = Room(owner=user, name="Greatestest room", messages_delete_able=True)
+        new_member = RoomMember(
+            member=user,
+            is_admin=False,
+            room=new_room,
+            left_room=False,
+        )
+        new_member2 = RoomMember(
+            member=user2,
+            is_admin=False,
+            room=new_room,
+            left_room=False,
+        )
+        room_message = RoomMessage(sender=user, content="I am the Man", room=new_room)
+
+        test_get_session.add_all(
+            [user, new_room, new_member, room_message, user2, new_member2]
+        )
+        await test_get_session.commit()
+        await test_get_session.flush()
+
+        # login user
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": email2,
+            "session_id": str(uuid4()),
+        }
+
+        response = await client.post(url="/api/v1/auth/login", json=login_payload)
+
+        assert response.status_code == 200
+
+        data: dict = response.json()
+
+        access_token = data["data"]["access_token"]["token"]
+
+        # delete room message
+
+        message_response = await client.put(
+            url=f"/api/v1/room-messages/{new_room.id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"message_ids": [room_message.id]},
+        )
+
+        assert message_response.status_code == 403
+
+        message_data = message_response.json()
+
+        assert message_data["message"] == "User has not enough Privilege"
+
+    @pytest.mark.asyncio
+    async def test_h_when_updating_message_passed_15_minutes_returns_400(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when updating message passed 15 minutes returns 400
+        """
+
+        # create user
+        email = f"{uuid4()}@gmail.com"
+        user = User(
+            email=email,
+            profile_photo="https://photo.com",
+            email_verified=True,
+        )
+        await user.set_idempotency_key(email)
+        user.set_password(register_input.get("password", ""))
+
+        # create room and add room member
+        new_room = Room(owner=user, name="Greatestest room", messages_delete_able=True)
+        new_member = RoomMember(
+            member=user,
+            is_admin=True,
+            room=new_room,
+            left_room=False,
+        )
+        room_message = RoomMessage(
+            sender=user,
+            content="I am the Man",
+            room=new_room,
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=20),
+        )
+
+        test_get_session.add_all([user, new_room, new_member, room_message])
+        await test_get_session.commit()
+        await test_get_session.flush()
+
+        # login user
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": email,
+            "session_id": str(uuid4()),
+        }
+
+        response = await client.post(url="/api/v1/auth/login", json=login_payload)
+
+        assert response.status_code == 200
+
+        data: dict = response.json()
+
+        access_token = data["data"]["access_token"]["token"]
+
+        # delete room message
+
+        message_response = await client.put(
+            url=f"/api/v1/room-messages/{new_room.id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"message_ids": [room_message.id]},
+        )
+
+        assert message_response.status_code == 400
+
+        message_data = message_response.json()
+
+        assert (
+            message_data["message"]
+            == "Cannot delete after 15 minutes of sending a message"
+        )
+
+    @pytest.mark.asyncio
+    async def test_j_when_messages_delete_able_is_False_returns_403(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when messages delete able is False returns 403
+        """
+
+        # create user
+        email = f"{uuid4()}@gmail.com"
+        user = User(
+            email=email,
+            profile_photo="https://photo.com",
+            email_verified=True,
+        )
+        await user.set_idempotency_key(email)
+        user.set_password(register_input.get("password", ""))
+
+        # create room and add room member
+        new_room = Room(owner=user, name="Greatestest room", messages_delete_able=False)
+        new_member = RoomMember(
+            member=user,
+            is_admin=False,
+            room=new_room,
+            left_room=False,
+        )
+        room_message = RoomMessage(
+            sender=user,
+            content="I am the Man",
+            room=new_room,
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=20),
+        )
+
+        test_get_session.add_all([user, new_room, new_member, room_message])
+        await test_get_session.commit()
+        await test_get_session.flush()
+
+        # login user
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": email,
+            "session_id": str(uuid4()),
+        }
+
+        response = await client.post(url="/api/v1/auth/login", json=login_payload)
+
+        assert response.status_code == 200
+
+        data: dict = response.json()
+
+        access_token = data["data"]["access_token"]["token"]
+
+        # delete room message
+
+        message_response = await client.put(
+            url=f"/api/v1/room-messages/{new_room.id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"message_ids": [room_message.id]},
+        )
+
+        assert message_response.status_code == 403
+
+        message_data = message_response.json()
+
+        assert (
+            message_data["message"] == "Admin privilege is needed for message deletion."
+        )
+
+    @pytest.mark.asyncio
+    async def test_k_when_is_admin_can_delete_any_message_successfully(
+        self, test_setup: None, client: AsyncClient, test_get_session: AsyncSession
+    ):
+        """
+        Tests when user not room member returns 403
+        """
+
+        # create user
+        email = f"{uuid4()}@gmail.com"
+        user = User(
+            email=email,
+            profile_photo="https://photo.com",
+            email_verified=True,
+        )
+        await user.set_idempotency_key(email)
+        user.set_password(register_input.get("password", ""))
+
+        email2 = f"{uuid4()}@gmail.com"
+        user2 = User(
+            email=email2,
+            profile_photo="https://photo.com",
+            email_verified=True,
+        )
+        await user2.set_idempotency_key(email2)
+        user2.set_password(register_input.get("password", ""))
+
+        # create room and add room member
+        new_room = Room(
+            owner=user,
+            name="Greatestest room",
+            messages_delete_able=False,
+            is_deactivated=True,
+        )
+        new_member = RoomMember(
+            member=user,
+            is_admin=False,
+            room=new_room,
+            left_room=False,
+        )
+        new_member2 = RoomMember(
+            member=user2,
+            is_admin=True,
+            room=new_room,
+            left_room=False,
+        )
+        room_message = RoomMessage(sender=user, content="I am the Man", room=new_room)
+
+        test_get_session.add_all(
+            [user, new_room, new_member, room_message, user2, new_member2]
+        )
+        await test_get_session.commit()
+        await test_get_session.flush()
+
+        # login user
+        login_payload = {
+            "password": register_input.get("password"),
+            "email": email2,
+            "session_id": str(uuid4()),
+        }
+
+        response = await client.post(url="/api/v1/auth/login", json=login_payload)
+
+        assert response.status_code == 200
+
+        data: dict = response.json()
+
+        access_token = data["data"]["access_token"]["token"]
+
+        message_response = await client.put(
+            url=f"/api/v1/room-messages/{new_room.id}",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"message_ids": [room_message.id]},
+        )
+
+        assert message_response.status_code == 200


### PR DESCRIPTION
### **Summary:**

This PR introduces support for **soft deleting one or more room messages**. Only the message **sender** (or an **admin** with proper permission) can delete messages, and **only within a configurable time window** (15 minutes by default). Messages are not permanently erased but are flagged as deleted and hidden from room participants.

---

### **Endpoint:**

`PUT /api/v1/room-messages/{room_id}`

---

### **Headers:**

* `Authorization: Bearer <access_token>`
* `Content-Type: application/json`
* `Accept: application/json`

---

### **Request Body Example:**

```json
{
  "message_ids": [
    "12312432-42345435-4564645",
    "1234324-23453-53454-645"
  ]
}
```

---

### ✅ **Success Response – 200 OK**

```json
{
  "message": "message(s) deleted successfully",
  "status_code": 200,
  "data": {}
}
```

---

### ❌ **Error Responses:**

**401 Unauthorized:**

```json
{
  "status_code": 401,
  "message": "Unauthorized",
  "data": {}
}
```

**403 Forbidden:**

* User is not the sender
* User is no longer in the room
* Message is no longer deletable
* Message belongs to another user and requester is not an admin

**404 Not Found:**

* Room or message(s) do not exist
* Message already deleted

**400 Bad Request:**

* Messages exceed deletion time window

---

### 🧪 **Test Coverage:**

Tests in `test_e2e_delete_room_message.py` — All passed ✅

| Test Case Description                                               | Status |
| ------------------------------------------------------------------- | ------ |
| test\_a\_user\_can\_delete\_room\_message\_successfully             | ✅      |
| test\_b\_when\_room\_not\_found\_returns\_404                       | ✅      |
| test\_c\_when\_user\_not\_room\_member\_returns\_403                | ✅      |
| test\_d\_when\_user\_left\_room\_returns\_403                       | ✅      |
| test\_e\_when\_message\_not\_found\_returns\_404                    | ✅      |
| test\_f\_when\_message\_is\_already\_deleted\_returns\_404          | ✅      |
| test\_g\_when\_user\_deletes\_another\_user\_message\_returns\_403  | ✅      |
| test\_h\_when\_updating\_message\_passed\_15\_minutes\_returns\_400 | ✅      |
| test\_j\_when\_messages\_delete\_able\_is\_False\_returns\_403      | ✅      |
| test\_k\_when\_is\_admin\_can\_delete\_any\_message\_successfully   | ✅      |

---

### 🔐 **Access Rules:**

* Only the **sender** can delete their own message within **15 minutes**
* Admins (with override permissions) can delete any message
* Users must still be members of the room

---

### 📌 Notes:

* This is a **soft delete** — messages remain in storage but are no longer visible
* Future extensions may include:

  * UI indicator for deleted messages
  * Admin audit trail